### PR TITLE
[FIX] default groups not being applied

### DIFF
--- a/lib/user_ispconfig.php
+++ b/lib/user_ispconfig.php
@@ -363,7 +363,7 @@ class OC_User_ISPCONFIG extends \OCA\user_ispconfig\ISPConfig_SOAP
         array_key_exists($user->getDomain(), $this->options['domain_config']) &&
         array_key_exists('groups', $this->options['domain_config'][$user->getDomain()]))
       return $this->options['domain_config'][$user->getDomain()]['groups'];
-    return $this->quota;
+    return $this->groups;
   }
 
   /**


### PR DESCRIPTION
Currently the default options' `default_groups => array(...)` isn't effective due to a bug in `getGroups()` call where it returns the wrong property instead of the one that is being initialized in the ctor.

Legacy workaround is to define domain specific options with exact same `groups => array(...)` data to override this malfunction.