### PR TITLE
Make it compatible with NC28

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Benötigt SOAP PHP Extension installiert und aktiviert und einen ISPConfig Remot
 	<website>https://github.com/SpicyWeb-de/nextcloud-user-ispconfig</website>
 	<repository type="git">https://github.com/SpicyWeb-de/nextcloud-user-ispconfig.git</repository>
 	<dependencies>
-		<nextcloud min-version="22" max-version="27" />
+		<nextcloud min-version="22" max-version="28" />
 		<lib>soap</lib>
 	</dependencies>
 	<types>

--- a/lib/base.php
+++ b/lib/base.php
@@ -25,6 +25,16 @@ abstract class Base extends \OC\User\Backend
 {
 
 	/**
+	 * Shortcut to get an instance of ILogger
+	 * @return \OCP\ILogger
+	 */
+	protected function logger()
+	{
+		return \OC::$server->getLogger();
+		// (min NC25) return \OCP\Server::get(LoggerInterface::class);
+	}
+
+	/**
 	 * Shortcut to get an instance of DB connection
 	 * @return \OCP\IDBConnection
 	 */

--- a/lib/ispconfig_soap.php
+++ b/lib/ispconfig_soap.php
@@ -7,8 +7,6 @@
 
 namespace OCA\User_ISPConfig;
 
-use OCP\Util;
-use OCP\ILogger;
 use SoapClient;
 use SoapFault;
 
@@ -70,7 +68,6 @@ abstract class ISPConfig_SOAP extends Base
    */
   protected function connectSoap()
   {
-    //Util::writeLog('user_ispconfig', "$this->location $this->uri", Util::ERROR);
     $this->soap = new SoapClient(null,
         array('location' => $this->location,
               'uri' => $this->uri,
@@ -113,7 +110,7 @@ abstract class ISPConfig_SOAP extends Base
         }
       } else {
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP error: SOAP session not established', ILogger::ERROR);
+        $this->logger()->error('SOAP error: SOAP session not established', ['app' => 'user_ispconfig']);
       }
     } catch (SoapFault $e) {
       $this->handleSOAPFault($e);
@@ -138,7 +135,7 @@ abstract class ISPConfig_SOAP extends Base
         }
       } else {
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP error: SOAP session not established', ILogger::ERROR);
+        $this->logger()->error('SOAP error: SOAP session not established', ['app' => 'user_ispconfig']);
       }
     } catch (SoapFault $e) {
       $this->handleSOAPFault($e);
@@ -159,7 +156,7 @@ abstract class ISPConfig_SOAP extends Base
   {
     try {
       if ($this->session) {
-        Util::writeLog('user_ispconfig', "New Password for $mailbox | $domain", ILogger::DEBUG);
+        $this->logger()->debug("New Password for $mailbox | $domain", ['app' => 'user_ispconfig']);
         $mailuser = $this->getMailuserByMailbox($mailbox, $domain);
         return $this->updateMailuser($mailuser, $newParams);
       }
@@ -181,7 +178,7 @@ abstract class ISPConfig_SOAP extends Base
     try {
       if ($this->session) {
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', "New Password for $uid", ILogger::DEBUG);
+        $this->logger()->debug("New Password for $uid", ['app' => 'user_ispconfig']);
         $mailuser = $this->getMailuserByLoginname($uid);
         return $this->updateMailuser($mailuser, $newParams);
       }
@@ -231,7 +228,7 @@ abstract class ISPConfig_SOAP extends Base
         return $this->soap->server_get_app_version($this->session);
       } else {
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP error: SOAP session not established', ILogger::ERROR);
+        $this->logger()->error('SOAP error: SOAP session not established', ['app' => 'user_ispconfig']);
       }
     } catch (SoapFault $e) {
       $this->handleSOAPFault($e);
@@ -254,7 +251,7 @@ abstract class ISPConfig_SOAP extends Base
         return $clientid;
       } else {
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP error: SOAP session not established', ILogger::ERROR);
+        $this->logger()->error('SOAP error: SOAP session not established', ['app' => 'user_ispconfig']);
       }
     } catch (SoapFault $e) {
       $this->handleSOAPFault($e);
@@ -274,19 +271,19 @@ abstract class ISPConfig_SOAP extends Base
     switch ($errorMsg) {
       case 'looks like we got no XML document':
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP Request failed: Invalid location or uri of ISPConfig SOAP Endpoint', ILogger::ERROR);
+        $this->logger()->error('user_ispconfig', 'SOAP Request failed: Invalid location or uri of ISPConfig SOAP Endpoint', ['app' => 'user_ispconfig']);
         break;
       case 'The login failed. Username or password wrong.':
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP Request failed: Invalid credentials of ISPConfig remote user', ILogger::ERROR);
+        $this->logger()->error('user_ispconfig', 'SOAP Request failed: Invalid credentials of ISPConfig remote user', ['app' => 'user_ispconfig']);
         break;
       case 'You do not have the permissions to access this function.':
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP Request failed: Ensure ISPConfig remote user has the following permissions: Customer Functions, Server Functions, E-Mail User Functions', ILogger::ERROR);
+        $this->logger()->error('user_ispconfig', 'SOAP Request failed: Ensure ISPConfig remote user has the following permissions: Customer Functions, Server Functions, E-Mail User Functions', ['app' => 'user_ispconfig']);
         break;
       default:
         /** @noinspection PhpDeprecationInspection */
-        Util::writeLog('user_ispconfig', 'SOAP Request failed: [' . $error->getCode() . '] ' . $error->getMessage(), ILogger::ERROR);
+        $this->logger()->error('user_ispconfig', 'SOAP Request failed: [' . $error->getCode() . '] ' . $error->getMessage(), ['app' => 'user_ispconfig']);
         break;
     }
   }

--- a/lib/user_ispconfig.php
+++ b/lib/user_ispconfig.php
@@ -107,7 +107,7 @@ class OC_User_ISPCONFIG extends ISPConfig_SOAP
   {
     if (!class_exists("SoapClient")) {
       /** @noinspection PhpDeprecationInspection */
-      OCP\Util::writeLog('user_ispconfig', 'ERROR: PHP soap extension is not installed or not enabled', OCP\ILogger::ERROR);
+      $this->logger()->error('ERROR: PHP soap extension is not installed or not enabled', ['app' => 'user_ispconfig']);
       return false;
     }
     if($this->useUIDMapping)
@@ -217,8 +217,6 @@ class OC_User_ISPCONFIG extends ISPConfig_SOAP
     // Get existing user from DB
     $returningUser = $this->getUserData($uid);
     if ($returningUser) {
-      /** @noinspection PhpDeprecationInspection */
-      // OCP\Util::writeLog('user_ispconfig', "Found returning user: $returningUser", OCP\Util::DEBUG);
       return array($returningUser);
     }
 
@@ -303,7 +301,7 @@ class OC_User_ISPCONFIG extends ISPConfig_SOAP
     if (is_array($mailuser) && count($mailuser)) {
       $result = ISPDomainUser::fromMailuserIfPasswordMatch($user->getUid(), $password, $mailuser);
       /** @noinspection PhpDeprecationInspection */
-      OCP\Util::writeLog('user_ispconfig', "Login result for $user: $result", OCP\ILogger::DEBUG);
+      $this->logger()->debug("Login result for $user: $result", ['app' => 'user_ispconfig']);
       return $result;
     }
     return false;
@@ -330,7 +328,7 @@ class OC_User_ISPCONFIG extends ISPConfig_SOAP
         }
       }
       /** @noinspection PhpDeprecationInspection */
-      OCP\Util::writeLog('user_ispconfig', "Login result for $uid: $domainuser", OCP\ILogger::DEBUG);
+      $this->logger()->debug("Login result for $uid: $domainuser", ['app' => 'user_ispconfig']);
       return $domainuser;
     }
     return false;


### PR DESCRIPTION
The deprecated function \OCP\Util\writeLog() class was removed in NC28. With this patch the ILogger service is directly injected into the base class to be used for logging.